### PR TITLE
fix: entrypoint for running scripts from Docker natively

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,16 +22,16 @@ jobs:
       - name: Run tests
         shell: bash -l {0}
         run: |
-          TargetPerla.pl \
+          ./TargetPerla.pl \
             -v -f -s .test/config.yaml \
             -o .test/output 
-          EXCAVATORDataPrepare.pl \
+          ./EXCAVATORDataPrepare.pl \
             -v -f \
             -s .test/sample_sheet.yaml \
             -t .test/output/hg38/SureSelectV7/w_30000 \
             -o .test/outputPrepare \
             -@ 3
-          EXCAVATORDataAnalysis.pl \
+          ./EXCAVATORDataAnalysis.pl \
             -v -f \
             -s .test/sample_file_list.yaml \
             -i .test/outputPrepare \

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,9 +22,6 @@ jobs:
       - name: Run tests
         shell: bash -l {0}
         run: |
-          eval "$(micromamba shell hook --shell bash)"
-          micromamba activate excavator2
-          export PATH="/opt/excavator2:${PATH}"
           TargetPerla.pl \
             -v -f -s .test/config.yaml \
             -o .test/output 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,6 @@ jobs:
           curl -L ftp-trace.ncbi.nlm.nih.gov/ReferenceSamples/giab/release/references/GRCh38/GRCh38_GIABv3_no_alt_analysis_set_maskedGRC_decoys_MAP2K3_KMT2C_KCNJ18.fasta.gz --output .test/ref/GRCh38_GIABv3_no_alt_analysis_set_maskedGRC_decoys_MAP2K3_KMT2C_KCNJ18.fasta.gz
           gzip -d .test/ref/GRCh38_GIABv3_no_alt_analysis_set_maskedGRC_decoys_MAP2K3_KMT2C_KCNJ18.fasta.gz
       - name: Run tests
-        shell: bash -l {0}
         run: |
           ./TargetPerla.pl \
             -v -f -s .test/config.yaml \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,22 @@
 FROM ghcr.io/mamba-org/micromamba:latest
 USER root
 RUN apt-get update && apt-get install -y curl
+
 COPY excavator2.yml /tmp/excavator2.yml
 RUN micromamba env create -f /tmp/excavator2.yml && \
     micromamba clean --all --yes
-RUN echo 'eval "$(micromamba shell hook --shell bash)"' >> /root/.bashrc
-RUN echo 'micromamba activate excavator2' >> /root/.bashrc
-RUN echo 'export PATH="/opt/excavator2:${PATH}"' >> /root/.bashrc
+
+# COPY your custom entrypoint script and make it executable
+COPY entrypoint.sh /usr/local/bin/entrypoint.sh
+RUN chmod +x /usr/local/bin/entrypoint.sh
+
 COPY excavator2 /opt/excavator2
 WORKDIR /opt/excavator2
+
 ENV PATH="/opt/excavator2:${PATH}"
+
+# Set the ENTRYPOINT to your new script
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
+
+# CMD provides the default command to the ENTRYPOINT
 CMD ["/opt/excavator2/excavator2.sh"]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -e
+
+# Activate the micromamba environment
+eval "$(micromamba shell hook --shell bash)"
+micromamba activate excavator2
+
+# Execute the command passed to this script (the Docker CMD)
+exec "$@"


### PR DESCRIPTION
This PR fixes the entrypoint for the Docker, that could be run now as in the readme via 

```
docker run ctglab/excavator2 TargetPerla.pl
```
